### PR TITLE
MIM-283: support planned maintenance on construction part

### DIFF
--- a/src/routes/planned-maintenance-route.ts
+++ b/src/routes/planned-maintenance-route.ts
@@ -21,8 +21,8 @@ export const routes = (router: KoaRouter) => {
    * @swagger
    * /planned-maintenance/{propertyObjectId}:
    *   get:
-   *     summary: Get all planned maintenance items by property object ID
-   *     description: Returns the planned maintenance items belonging to roof or facade based on property object code.
+   *     summary: Gets the planned maintenance on a construction part by property object ID
+   *     description: Returns the planned maintenance belonging to a construction part based on property object code.
    *     tags:
    *       - Planned Maintenance
    *     parameters:
@@ -31,7 +31,7 @@ export const routes = (router: KoaRouter) => {
    *         required: true
    *         schema:
    *           type: string
-   *         description: The property object id of the roof or facade
+   *         description: The property object id of the construction part
    *     responses:
    *       200:
    *         description: Successfully retrieved the planned maintenance


### PR DESCRIPTION
PR för att hämta allt planerat underhåll på ett tak eller fasad. 

* modeller för planerat underhåll och åtgärdskoder
* enkel endpoint och service för att hämta planerat underhåll på tak/fasad

Till skillnad från våra andra resurser så finns det vad jag kan se inget enkelt sätt att använda en annan identifierare än property object id (keycmobj). För att hämta planerat underhåll bör man därför först hämta ut tak/fasad (construction part) och sedan ropa på den nya endpointen i detta PR med propertyObjectId från construction part. 

Kvar att göra: 

* hateoslänkar
* definiera schema för typ 