### PR TITLE
MIM-472: Get work orders in ResidenceView

### DIFF
--- a/packages/property-base/src/adapters/residence-adapter.ts
+++ b/packages/property-base/src/adapters/residence-adapter.ts
@@ -25,6 +25,11 @@ export type ResidenceWithRelations = Prisma.ResidenceGetPayload<{
       include: {
         property: true
         building: true
+        propertyStructures: {
+          select: {
+            rentalId: true
+          }
+        }
       }
     }
   }
@@ -53,6 +58,11 @@ export const getResidenceById = async (
           include: {
             property: true,
             building: true,
+            propertyStructures: {
+              select: {
+                rentalId: true,
+              },
+            },
           },
         },
       },

--- a/packages/property-base/src/routes/residences-route.ts
+++ b/packages/property-base/src/routes/residences-route.ts
@@ -159,6 +159,11 @@ export const routes = (router: KoaRouter) => {
       // TODO: find out why building is null in residence
       //const building = await getBuildingByCode(residence.buildingCode)
 
+      const rentalId =
+        residence.propertyObject?.propertyStructures?.length > 0
+          ? residence.propertyObject.propertyStructures[0].rentalId
+          : null
+
       const parsedResidence = ResidenceDetailedSchema.parse({
         id: residence.id,
         code: residence.code,
@@ -227,6 +232,7 @@ export const routes = (router: KoaRouter) => {
               residence.propertyObject?.energyReceived || undefined,
             energyIndex: residence.propertyObject?.energyIndex?.toNumber(),
           },
+          rentalId,
         },
       } satisfies ResidenceDetails)
 

--- a/packages/property-base/src/types/residence.ts
+++ b/packages/property-base/src/types/residence.ts
@@ -86,6 +86,7 @@ export const ResidenceDetailedSchema = ResidenceSchema.extend({
       energyReceived: z.date().optional(),
       energyIndex: z.number().optional(),
     }),
+    rentalId: z.string().nullable(),
   }),
 })
 

--- a/packages/property-tree/src/components/views/ResidenceView.tsx
+++ b/packages/property-tree/src/components/views/ResidenceView.tsx
@@ -10,6 +10,7 @@ import { StatCard } from '../shared/StatCard'
 import { residenceService } from '@/services/api'
 import { useQuery } from '@tanstack/react-query'
 import { Badge } from '@/components/ui/Badge'
+import { workOrderService } from '@/services/api/core/workOrderService'
 
 function LoadingSkeleton() {
   return (
@@ -55,6 +56,15 @@ export function ResidenceView() {
     enabled: !!residenceId,
   })
 
+  const workOrdersQuery = useQuery({
+    queryKey: ['residence_work_orders', residenceId],
+    queryFn: () =>
+      workOrderService.getWorkOrdersForResidence(
+        residenceQuery.data!.propertyObject.rentalId!
+      ),
+    enabled: !!residenceQuery.data?.propertyObject.rentalId,
+  })
+
   const buildingCode = state?.buildingCode
   const staircaseCode = state?.staircaseCode
 
@@ -75,6 +85,8 @@ export function ResidenceView() {
       </div>
     )
   }
+
+  console.log(workOrdersQuery.data)
 
   return (
     <div className="p-8 animate-in">

--- a/packages/property-tree/src/services/api/core/generated/api-types.ts
+++ b/packages/property-tree/src/services/api/core/generated/api-types.ts
@@ -2106,6 +2106,7 @@ export interface components {
           energyReceived?: string;
           energyIndex?: number;
         };
+        rentalId: string | null;
       };
     };
     Staircase: {

--- a/packages/property-tree/src/services/api/core/workOrderService.ts
+++ b/packages/property-tree/src/services/api/core/workOrderService.ts
@@ -1,0 +1,20 @@
+import { GET } from './base-api'
+import { components } from './generated/api-types'
+
+export const workOrderService = {
+  async getWorkOrdersForResidence(
+    residenceId: string
+  ): Promise<components['schemas']['WorkOrder'][]> {
+    const { data, error } = await GET(
+      '/workOrders/rentalPropertyId/{rentalPropertyId}',
+      {
+        params: { path: { rentalPropertyId: residenceId } },
+      }
+    )
+
+    if (error) throw error
+    if (!data.content) throw new Error('No data returned from API')
+
+    return data.content.workOrders ?? []
+  },
+}

--- a/packages/property-tree/src/services/api/generated/api-types.ts
+++ b/packages/property-tree/src/services/api/generated/api-types.ts
@@ -592,6 +592,7 @@ export interface components {
           energyReceived?: string;
           energyIndex?: number;
         };
+        rentalId: string | null;
       };
     };
     Building: {


### PR DESCRIPTION
property-base:

- Gets the `rentalId` for a `Residence` from xpand

property-tree:

- Gets work orders based on the `rentalId` that is returned from onecore-core