### PR TITLE
MIM-532: add rental information type

### DIFF
--- a/packages/property-base/prisma/schema/PropertyObject_cmobj.prisma
+++ b/packages/property-base/prisma/schema/PropertyObject_cmobj.prisma
@@ -23,6 +23,7 @@ model PropertyObject {
   administrativeUnit AdministrativeUnit? //@relation("PropertyObjectToAdministrativeUnit")
   propertyArea       PropertyArea[] //@relation("PropertyObjectToPropertyArea")
   property           Property? //@relation("PropertyObjectToProperty") //todo: fix this relation
+  rentalInformation  RentalInformation? @relation("PropertyObjectToRentalInformation")
 
   rentalObject RentalObject? //@relation("PropertyObjectToRentalObject")
   //company Company? @relation("PropertyObjectToCompany")

--- a/packages/property-base/prisma/schema/RentalInformationType_hyint.prisma
+++ b/packages/property-base/prisma/schema/RentalInformationType_hyint.prisma
@@ -1,0 +1,23 @@
+model RentalInformationType {
+  @@map("hyint")
+
+  id String @id(map: "pkhyint") @map("keyhyint") @db.Char(15)
+  code String @map("code") @db.Char(10)
+  name String? @map("caption") @db.Char(30)
+  // Exclude unused fields
+
+// waitingListTypeId String? @map("keybkkty") @db.Char(15)
+// minimumAge Int? @map("minage") @db.TinyInt
+// maximumAge Int? @map("maxage") @db.TinyInt
+// housingType Int @default(0, map: "DF__hyint__lmcat__66796CD3") @map("lmcat") @db.TinyInt
+// publishStatus Int @default(0, map: "DF__hyint__publicera__676D910C") @map("publiceras") @db.TinyInt
+// apartmentInspectionStatus Int @default(1, map: "DF__hyint__lbcreate__6861B545") @map("lbcreate") @db.TinyInt
+// turnoverVisibility Int @default(0, map: "DF__hyint__tuovisibl__6955D97E") @map("tuovisible") @db.TinyInt
+// familySituationStatus Int @default(0, map: "DF__hyint__familysit__6A49FDB7") @map("familysit") @db.TinyInt
+// timestamp String @map("timestamp") @db.Char(10)
+
+  rentalInformations RentalInformation[] // Previously hyinf; converted to use the new model name
+// waitingListType WaitingListType? @relation(fields: [waitingListTypeId], references: [waitingListTypeId], onDelete: NoAction, onUpdate: NoAction, map: "fkhyintkeybkkty")
+
+// @@index([waitingListTypeId], map: "fkhyintbkkty")
+}

--- a/packages/property-base/prisma/schema/RentalInformation_hyinf.prisma
+++ b/packages/property-base/prisma/schema/RentalInformation_hyinf.prisma
@@ -90,7 +90,7 @@ model RentalInformation {
   // quantityType3 cmvat_hyinf_keycmvat3Tocmvat cmvat? @relation("hyinf_keycmvat3Tocmvat", fields: [quantityTypeId3], references: [keycmvat], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycmvat3")
   // quantityType4 cmvat_hyinf_keycmvat4Tocmvat cmvat? @relation("hyinf_keycmvat4Tocmvat", fields: [quantityTypeId4], references: [keycmvat], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycmvat4")
   rentalInformationType RentalInformationType @relation(fields: [rentalInformationTypeId], references: [id], onUpdate: NoAction, map: "fkhyinfkeyhyint")
-
+  propertyObject PropertyObject @relation("PropertyObjectToRentalInformation", fields: [propertyObjectId], references: [id], map: "fkhyinfkeycmobj")
 // @@index([heatingId], map: "fkhyinfbahea")
 // @@index([shownByUserId], map: "fkhyinfbkvis")
 // @@index([creditTemplateId], map: "fkhyinfcmcte")

--- a/packages/property-base/prisma/schema/RentalInformation_hyinf.prisma
+++ b/packages/property-base/prisma/schema/RentalInformation_hyinf.prisma
@@ -1,0 +1,105 @@
+model RentalInformation {
+  @@map("hyinf")
+  id String @id(map: "pkhyinf") @map("keyhyinf") @db.Char(15)
+  propertyObjectId String @unique(map: "akhyinf1") @map("keycmobj") @db.Char(15)
+  rentalInformationTypeId String @map("keyhyint") @db.Char(15)
+  // Exclude unused fields
+
+// shownByUserId String? @map("keybkvis") @db.Char(15) // TODO: Confirm relation name if changed
+// indexSeriesId String? @map("keycmind") @db.Char(15)
+// indexValueId String? @map("keycminv") @db.Char(15)
+// quantityTypeId String? @map("keycmvat") @db.Char(15)
+// quantityTypeId2 String? @map("keycmvat2") @db.Char(15)
+// quantityTypeId3 String? @map("keycmvat3") @db.Char(15)
+// quantityTypeId4 String? @map("keycmvat4") @db.Char(15)
+// taxAreaId String? @map("keyhyvaa") @db.Char(15)
+// heatingId String? @map("keybahea") @db.Char(15)
+// renovationExemptionId String? @map("keybarex") @db.Char(15)
+// creditTemplateId String? @map("keycmcte") @db.Char(15)
+// rentId String? @map("hyresid") @db.VarChar(30)
+// generation Int? @map("generation") @db.SmallInt
+// startGeneration Int? @map("startgen") @db.TinyInt
+// apartmentNumber String? @map("lmnr") @db.Char(5)
+// housingNumber String? @map("prynumber") @db.VarChar(30)
+// shareNumber String? @map("shareno") @db.VarChar(60)
+// tenureForm Int? @map("upplform") @db.TinyInt
+// currentTenureForm Int? @map("upplformnu") @db.TinyInt
+// isShortTermRental Int @map("shortstay") @db.TinyInt
+// sharePercentage Decimal? @map("andelstal") @db.Decimal(22, 7)
+// rentDistributionFactor Decimal? @map("aixrent") @db.Decimal(8, 7)
+// shareValue Float? @map("sharevalue") @db.Money
+// voteCount Int? @map("votecount") @db.TinyInt
+// depositAdvance Float? @map("insatspre") @db.Money
+// depositForfeit Float? @map("insatsfors") @db.Money // deposit Float? @map("insats") @db.Money // depositDate DateTime? @map("inputdate") @db.DateTime
+// tenureFee Float? @map("upplavg") @db.Money
+// tenureFeeDate DateTime? @map("letfeedate") @db.DateTime
+// irrevocableCapitalContribution Float? @map("oaterkap") @db.Money
+// originalAnnualFee Float? @map("planarsavg") @db.Money
+// firstOccupancyDate DateTime? @map("inflyttdat") @db.DateTime
+// queueManagement Int? @map("direktuth") @db.TinyInt
+// baseRentAmount Float? @map("akthyratot") @db.Money
+// contractBaseRent Float? @map("konthyra") @db.Money
+// isDraft Int @default(0, map: "DF__hyinf__draft__535320DE") @map("draft") @db.TinyInt
+// doNotInvoiceDeposit Int @map("ejbrinsats") @db.TinyInt
+// doNotAllocateToInternalFund Int @map("ejbrfnd") @db.TinyInt
+// statisticsFrom DateTime @map("statfrom") @db.DateTime
+// statisticsTo DateTime @map("stattom") @db.DateTime
+// rentLossFrom DateTime? @map("lossfrom") @db.DateTime
+// rentLossTo DateTime? @map("lossto") @db.DateTime
+// salesStop Int @map("saljstopp") @db.TinyInt
+// housingEvaluationType Int @default(0, map: "DF__hyinf__pointtype__54474517") @map("pointtype") @db.TinyInt
+// housingAllowance Int @default(0, map: "DF__hyinf__allowance__553B6950") @map("allowance") @db.TinyInt
+// housingEnergyClass Int @default(0, map: "DF__hyinf__fohenergy__562F8D89") @map("fohenergyc") @db.TinyInt
+// targetRentPercentage Decimal? @map("targetperc") @db.Decimal(4, 1)
+// targetRentAmount Float? @map("targetrent") @db.Money
+// evaluationPoints Int? @map("points") @db.SmallInt
+// minOccupants Int? @map("persmin") @db.TinyInt
+// maxOccupants Int? @map("persmax") @db.TinyInt
+// minAge Int? @map("persagemin") @db.TinyInt
+// maxAge Int? @map("persagemax") @db.TinyInt
+// minTenureMonths Int? @map("tentimemin") @db.TinyInt
+// minIncomeRentFactor Decimal? @map("increntmin") @db.Decimal(4, 2)
+// additionalInfo String? @map("otherinfo") @db.VarChar(200)
+// renovationExemptionComment String? @map("rexcomment") @db.VarChar(200)
+// firstClassId Int @default(0, map: "DF__hyinf__fcobject__5723B1C2") @map("fcobject") @db.TinyInt
+// upgradeStandard Int @default(0, map: "DF__hyinf__fcstatus__5817D5FB") @map("fcstatus") @db.TinyInt
+// upgradeNeed Int @default(0, map: "DF__hyinf__fcupgneed__590BFA34") @map("fcupgneed") @db.TinyInt
+// lastUpgradeDate DateTime? @map("fcdate") @db.DateTime
+// upgradeComment String? @map("fccomment") @db.VarChar(250)
+// isBGUCovered Int @default(0, map: "DF__hyinf__bguused__5A001E6D") @map("bguused") @db.TinyInt
+// hasLakeView Int @default(0, map: "DF__hyinf__lakeview__5AF442A6") @map("lakeview") @db.TinyInt
+// vatRate Decimal @default(0, map: "DF__hyinf__vatstat__5BE866DF") @map("vatstat") @db.Decimal(4, 2)
+// purposeLabel Int @default(1, map: "DF__hyinf__label__5CDC8B18") @map("label") @db.TinyInt
+// isRenovated Int @default(0, map: "DF__hyinf__renovatio__5DD0AF51") @map("renovation") @db.TinyInt
+// daebStatus Int @default(1, map: "DF__hyinf__daeb__5EC4D38A") @map("daeb") @db.TinyInt
+// standardYearRent Float? @map("stdyrrent") @db.Money
+// discountFee Float @default(0, map: "DF__hyinf__discfee__5FB8F7C3") @map("discfee") @db.Money
+// rentCalculationMethod Int @default(0, map: "DF__hyinf__rentcalcm__60AD1BFC") @map("rentcalcm") @db.TinyInt
+// deleteMark Int @default(0, map: "DF__hyinf__deletemar__61A14035") @map("deletemark") @db.TinyInt
+// timestamp String @map("timestamp") @db.Char(10)
+
+// heating Heating? @relation(fields: [heatingId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfbahea")
+// creditTemplate CreditTemplate? @relation(fields: [creditTemplateId], references: [id], onUpdate: NoAction, map: "fkhyinfcmcte")
+
+  // TODO: change relations when knowing the new model names
+  // indexSeries cmind? @relation(fields: [indexSeriesId], references: [keycmind], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycmind")
+  // indexValue IndexValue? @relation(fields: [indexValueId], references: [indexValueId], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycminv")
+  // propertyObject cmobj @relation(fields: [propertyObjectId], references: [keycmobj], onDelete: Cascade, onUpdate: NoAction, map: "fkhyinfkeycmobj")
+  // quantityType cmvat_hyinf_keycmvatTocmvat cmvat? @relation("hyinf_keycmvatTocmvat", fields: [quantityTypeId], references: [keycmvat], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycmvat")
+  // quantityType2 cmvat_hyinf_keycmvat2Tocmvat cmvat? @relation("hyinf_keycmvat2Tocmvat", fields: [quantityTypeId2], references: [keycmvat], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycmvat2")
+  // quantityType3 cmvat_hyinf_keycmvat3Tocmvat cmvat? @relation("hyinf_keycmvat3Tocmvat", fields: [quantityTypeId3], references: [keycmvat], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycmvat3")
+  // quantityType4 cmvat_hyinf_keycmvat4Tocmvat cmvat? @relation("hyinf_keycmvat4Tocmvat", fields: [quantityTypeId4], references: [keycmvat], onDelete: NoAction, onUpdate: NoAction, map: "fkhyinfkeycmvat4")
+  rentalInformationType RentalInformationType @relation(fields: [rentalInformationTypeId], references: [id], onUpdate: NoAction, map: "fkhyinfkeyhyint")
+
+// @@index([heatingId], map: "fkhyinfbahea")
+// @@index([shownByUserId], map: "fkhyinfbkvis")
+// @@index([creditTemplateId], map: "fkhyinfcmcte")
+// @@index([indexSeriesId], map: "fkhyinfcmind")
+// @@index([indexValueId], map: "fkhyinfcminv")
+// @@index([quantityTypeId], map: "fkhyinfcmvat")
+// @@index([quantityTypeId2], map: "fkhyinfcmvat2")
+// @@index([quantityTypeId3], map: "fkhyinfcmvat3")
+// @@index([quantityTypeId4], map: "fkhyinfcmvat4")
+// @@index([rentalInformationTypeId], map: "fkhyinfhyint")
+// @@index([rentId], map: "inhyinf_2J70GWSR9")
+}

--- a/packages/property-base/src/adapters/residence-adapter.ts
+++ b/packages/property-base/src/adapters/residence-adapter.ts
@@ -24,6 +24,7 @@ export type ResidenceWithRelations = Prisma.ResidenceGetPayload<{
     residenceType: true
     propertyObject: {
       include: {
+        rentalInformation: { include: { rentalInformationType: true } }
         propertyStructures: {
           select: {
             rentalId: true
@@ -59,6 +60,7 @@ export const getResidenceById = async (
         residenceType: true,
         propertyObject: {
           include: {
+            rentalInformation: { include: { rentalInformationType: true } },
             propertyStructures: {
               select: {
                 rentalId: true,

--- a/packages/property-base/src/routes/residences-route.ts
+++ b/packages/property-base/src/routes/residences-route.ts
@@ -311,6 +311,16 @@ export const routes = (router: KoaRouter) => {
             energyIndex: residence.propertyObject?.energyIndex?.toNumber(),
           },
           rentalId,
+          rentalInformation: !residence.propertyObject?.rentalInformation
+            ? null
+            : {
+                type: {
+                  code: residence.propertyObject.rentalInformation
+                    .rentalInformationType.code,
+                  name: residence.propertyObject.rentalInformation
+                    .rentalInformationType.name,
+                },
+              },
         },
         property: {
           code: residence.propertyObject.propertyStructures[0].propertyCode,

--- a/packages/property-base/src/types/residence.ts
+++ b/packages/property-base/src/types/residence.ts
@@ -107,6 +107,14 @@ export const ResidenceDetailedSchema = z.object({
       energyIndex: z.number().optional(),
     }),
     rentalId: z.string().nullable(),
+    rentalInformation: z
+      .object({
+        type: z.object({
+          code: z.string(),
+          name: z.string().nullable(),
+        }),
+      })
+      .nullable(),
   }),
   property: z.object({
     name: z.string().nullable(),

--- a/packages/property-tree/src/components/residence/ResidenceBasicInfo.tsx
+++ b/packages/property-tree/src/components/residence/ResidenceBasicInfo.tsx
@@ -4,8 +4,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/v2/Card'
-import { ResidenceDetails } from '@/services/types'
 import { useIsMobile } from '../hooks/useMobile'
+import { components } from '@/services/api/core/generated/api-types'
+
+type ResidenceDetails = components['schemas']['ResidenceDetails']
 
 interface ResidenceBasicInfoProps {
   residence: ResidenceDetails
@@ -35,9 +37,9 @@ export const ResidenceBasicInfo = ({ residence }: ResidenceBasicInfoProps) => {
             className={`grid ${isMobile ? 'grid-cols-1 gap-y-4' : 'grid-cols-2 md:grid-cols-3 gap-4'}`}
           >
             <div>
-              <p className="text-sm text-muted-foreground">Namn</p>
+              <p className="text-sm text-muted-foreground">Hyresobjektstyp</p>
               <p className="font-medium">
-                {residence.residenceType.name}, {residence.name}
+                {residence.propertyObject?.rentalInformation?.type.name}
               </p>
             </div>
             <div>

--- a/packages/property-tree/src/services/api/core/generated/api-types.ts
+++ b/packages/property-tree/src/services/api/core/generated/api-types.ts
@@ -2327,6 +2327,12 @@ export interface components {
           energyIndex?: number;
         };
         rentalId: string | null;
+        rentalInformation: ({
+          type: {
+            code: string;
+            name: string | null;
+          };
+        }) | null;
       };
       property: {
         name: string | null;

--- a/packages/property-tree/src/services/api/generated/api-types.ts
+++ b/packages/property-tree/src/services/api/generated/api-types.ts
@@ -621,6 +621,12 @@ export interface components {
           energyIndex?: number;
         };
         rentalId: string | null;
+        rentalInformation: ({
+          type: {
+            code: string;
+            name: string | null;
+          };
+        }) | null;
       };
       property: {
         name: string | null;

--- a/packages/property-tree/src/services/api/residenceService.ts
+++ b/packages/property-tree/src/services/api/residenceService.ts
@@ -1,5 +1,8 @@
-import { Residence, ResidenceDetails } from '../types'
+import { Residence } from '../types'
 import { GET } from './core/base-api'
+import { components } from './core/generated/api-types'
+
+type ResidenceDetails = components['schemas']['ResidenceDetails']
 
 export const residenceService = {
   async getByBuildingCode(buildingCode: string): Promise<Residence[]> {

--- a/packages/property-tree/src/services/types.ts
+++ b/packages/property-tree/src/services/types.ts
@@ -7,7 +7,6 @@ export type Property = components['schemas']['Property']
 export type Building = components['schemas']['Building']
 export type Staircase = components['schemas']['Staircase']
 export type Residence = components['schemas']['Residence']
-export type ResidenceDetails = components['schemas']['ResidenceDetails']
 export type Room = components['schemas']['Room']
 export type Component = components['schemas']['Component']
 


### PR DESCRIPTION
- Adds prisma schema for rental information (mappings from hyinf and hyint)
- include in residence query
https://linear.app/mimer-onecore/issue/MIM-532/grundinformation-hyresobjektstyp