### PR TITLE
MIM-531: Fetch size (yta) from xpand and display in residence basic information

### DIFF
--- a/packages/property-base/prisma/schema/QuantityCategoryLink_cmvap.prisma
+++ b/packages/property-base/prisma/schema/QuantityCategoryLink_cmvap.prisma
@@ -1,0 +1,14 @@
+model QuantityCategoryLink {
+  id             String @id @map("keycmvap") @db.Char(15)
+  quantityTypeId String @map("keycmvat") @db.Char(15)
+  categoryId     String @map("keycmtyp") @db.Char(15)
+  timestamp      String @map("timestamp") @db.Char(10)
+
+  quantityType QuantityType     @relation(fields: [quantityTypeId], references: [id])
+  category     QuantityCategory @relation(fields: [categoryId], references: [id])
+
+  @@unique([quantityTypeId, categoryId])
+  @@index([categoryId])
+  @@index([quantityTypeId])
+  @@map("cmvap")
+}

--- a/packages/property-base/prisma/schema/QuantityCategory_cmtyp.prisma
+++ b/packages/property-base/prisma/schema/QuantityCategory_cmtyp.prisma
@@ -1,0 +1,20 @@
+model QuantityCategory {
+  id                 String  @id @map("keycmtyp") @db.Char(15)
+  parentCategoryId   String? @map("keycmtyp2") @db.Char(15)
+  name               String  @map("caption") @db.VarChar(60)
+  sortOrder          Int     @default(0) @map("sortorder") @db.SmallInt
+  allowTextValues    Int     @default(0) @map("txtallow") @db.TinyInt
+  allowSubCategories Int     @default(0) @map("sublvls") @db.TinyInt
+  isPublished        Int     @default(1) @map("publish") @db.TinyInt
+  module             String? @map("validmdl") @db.VarChar(80)
+  isHidden           Int     @default(0) @map("hidetype") @db.TinyInt
+  systemStandard     Int     @default(0) @map("repab") @db.TinyInt
+  timestamp          String  @map("timestamp") @db.Char(10)
+
+  parent   QuantityCategory?      @relation("CategoryHierarchy", fields: [parentCategoryId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  subtypes QuantityCategory[]     @relation("CategoryHierarchy")
+  links    QuantityCategoryLink[]
+
+  @@index([parentCategoryId])
+  @@map("cmtyp")
+}

--- a/packages/property-base/prisma/schema/QuantityType_cmvat.prisma
+++ b/packages/property-base/prisma/schema/QuantityType_cmvat.prisma
@@ -1,0 +1,16 @@
+model QuantityType {
+  id             String  @id @map("keycmvat") @db.Char(15)
+  unitId         String? @map("keycmuni") @db.Char(15)
+  name           String  @map("caption") @db.VarChar(30)
+  inputMask      String? @map("inputmask") @db.VarChar(30)
+  locked         Int     @default(0) @map("locked") @db.TinyInt
+  systemStandard Int     @default(0) @map("repabkod") @db.TinyInt
+  timestamp      String  @map("timestamp") @db.Char(10)
+
+  quantityValues QuantityValue[]
+  categoryLinks  QuantityCategoryLink[]
+
+  @@index([unitId])
+  @@index([name])
+  @@map("cmvat")
+}

--- a/packages/property-base/prisma/schema/QuantityValue_cmval.prisma
+++ b/packages/property-base/prisma/schema/QuantityValue_cmval.prisma
@@ -1,13 +1,12 @@
 model QuantityValue {
-  id             String @id @map("keycmval") @db.Char(15)
-  tableName      String @map("keydbtbl") @db.Char(15)
-  code           String @map("keycode") @db.Char(15)
-  quantityTypeId String @map("keycmvat") @db.Char(15)
-  value          Float  @default(0.0) @db.Money
-  timestamp      String @map("timestamp") @db.Char(10)
+  id              String @id @map("keycmval") @db.Char(15)
+  tableName       String @map("keydbtbl") @db.Char(15)
+  code            String @map("keycode") @db.Char(15)
+  quantityTypeId  String @map("keycmvat") @db.Char(15)
+  value           Float  @default(0.0) @db.Money
+  timestamp       String @map("timestamp") @db.Char(10)
 
-  quantityType QuantityType @relation(fields: [quantityTypeId], references: [id])
-  residence    Residence?   @relation(name: "ResidenceToQuantityValue", fields: [code], references: [propertyObjectId])
+  quantityType    QuantityType @relation(fields: [quantityTypeId], references: [id])
 
   @@unique([quantityTypeId, code])
   @@index([quantityTypeId])

--- a/packages/property-base/prisma/schema/QuantityValue_cmval.prisma
+++ b/packages/property-base/prisma/schema/QuantityValue_cmval.prisma
@@ -1,0 +1,17 @@
+model QuantityValue {
+  id             String @id @map("keycmval") @db.Char(15)
+  tableName      String @map("keydbtbl") @db.Char(15)
+  code           String @map("keycode") @db.Char(15)
+  quantityTypeId String @map("keycmvat") @db.Char(15)
+  value          Float  @default(0.0) @db.Money
+  timestamp      String @map("timestamp") @db.Char(10)
+
+  quantityType QuantityType @relation(fields: [quantityTypeId], references: [id])
+  residence    Residence?   @relation(name: "ResidenceToQuantityValue", fields: [code], references: [propertyObjectId])
+
+  @@unique([quantityTypeId, code])
+  @@index([quantityTypeId])
+  @@index([code])
+  @@index([tableName])
+  @@map("cmval")
+}

--- a/packages/property-base/prisma/schema/Residence_balgh.prisma
+++ b/packages/property-base/prisma/schema/Residence_balgh.prisma
@@ -36,9 +36,11 @@ model Residence {
   toDate                     DateTime  @map("tdate") @db.DateTime
   timestamp                  String    @map("timestamp") @db.Char(10) // TODO: consider changing timestamp later
 
-  residenceType  ResidenceType  @relation(fields: [residenceTypeId], references: [id], onUpdate: NoAction, map: "fkbalghkeybalgt ")
-  propertyObject PropertyObject @relation(fields: [propertyObjectId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fkbalghkeycmobj")
-  comments       TypeText[]     @relation("ResidenceToTypeText")
+  residenceType  ResidenceType   @relation(fields: [residenceTypeId], references: [id], onUpdate: NoAction, map: "fkbalghkeybalgt ")
+  propertyObject PropertyObject  @relation(fields: [propertyObjectId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fkbalghkeycmobj")
+  comments       TypeText[]      @relation("ResidenceToTypeText")
+  quantityValues QuantityValue[] @relation(name: "ResidenceToQuantityValue")
+
   // TODO: Verify relation for checklistId as the InspectionProtocol model was provided but fields need to be verified
   // inspectionProtocol InspectionProtocol? @relation(fields: [checklistId], references: [inspectionProtocolId], onUpdate: NoAction, map: "fkbalghkeylbpro ")
 

--- a/packages/property-base/prisma/schema/Residence_balgh.prisma
+++ b/packages/property-base/prisma/schema/Residence_balgh.prisma
@@ -39,7 +39,6 @@ model Residence {
   residenceType  ResidenceType   @relation(fields: [residenceTypeId], references: [id], onUpdate: NoAction, map: "fkbalghkeybalgt ")
   propertyObject PropertyObject  @relation(fields: [propertyObjectId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "fkbalghkeycmobj")
   comments       TypeText[]      @relation("ResidenceToTypeText")
-  quantityValues QuantityValue[] @relation(name: "ResidenceToQuantityValue")
 
   // TODO: Verify relation for checklistId as the InspectionProtocol model was provided but fields need to be verified
   // inspectionProtocol InspectionProtocol? @relation(fields: [checklistId], references: [inspectionProtocolId], onUpdate: NoAction, map: "fkbalghkeylbpro ")

--- a/packages/property-base/src/adapters/residence-adapter.ts
+++ b/packages/property-base/src/adapters/residence-adapter.ts
@@ -176,6 +176,47 @@ export type ResidenceSearchResult = Prisma.ResidenceGetPayload<{
   }
 }>
 
+export const getResidenceSizeById = async (residenceId: string) => {
+  try {
+    const result = await prisma.quantityValue
+      .findFirst({
+        where: {
+          quantityTypeId: 'BOA',
+          residence: {
+            id: residenceId,
+          },
+          quantityType: {
+            categoryLinks: {
+              some: { categoryId: 'balgh' },
+            },
+          },
+        },
+        include: {
+          quantityType: {
+            select: {
+              id: true,
+              name: true,
+              unitId: true,
+              categoryLinks: false,
+            },
+          },
+          residence: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      })
+      .then(trimStrings)
+
+    return result
+  } catch (err) {
+    logger.error({ err }, 'residence-adapter.getResidenceSizeById')
+    throw err
+  }
+}
+
 export const searchResidences = async (
   q: string
 ): Promise<Array<ResidenceSearchResult>> => {

--- a/packages/property-base/src/adapters/residence-adapter.ts
+++ b/packages/property-base/src/adapters/residence-adapter.ts
@@ -176,6 +176,40 @@ export type ResidenceSearchResult = Prisma.ResidenceGetPayload<{
   }
 }>
 
+export const getResidenceSizeByRentalId = async (rentalId: string) => {
+  try {
+    // Get property structure information for the residence
+    const propertyInfo = await prisma.propertyStructure.findFirst({
+      where: {
+        rentalId,
+        propertyObject: { objectTypeId: 'balgh' },
+        NOT: { propertyCode: null },
+      },
+      select: {
+        name: true,
+        propertyObject: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    })
+
+    // Get area size for the property object
+    const areaSize = await prisma.quantityValue.findFirst({
+      where: {
+        code: propertyInfo.propertyObject.id,
+        quantityTypeId: 'BOA',
+      },
+    })
+
+    return areaSize
+  } catch (err) {
+    logger.error({ err }, 'residence-adapter.getResidenceSizeById')
+    throw err
+  }
+}
+
 export const searchResidences = async (
   q: string
 ): Promise<Array<ResidenceSearchResult>> => {

--- a/packages/property-base/src/adapters/residence-adapter.ts
+++ b/packages/property-base/src/adapters/residence-adapter.ts
@@ -195,6 +195,13 @@ export const getResidenceSizeByRentalId = async (rentalId: string) => {
       },
     })
 
+    if (propertyInfo === null) {
+      logger.warn(
+        'residence-adapter.getResidenceSizeByRentalId: No property structure found for rentalId'
+      )
+      return null
+    }
+
     // Get area size for the property object
     const areaSize = await prisma.quantityValue.findFirst({
       where: {

--- a/packages/property-base/src/adapters/residence-adapter.ts
+++ b/packages/property-base/src/adapters/residence-adapter.ts
@@ -176,47 +176,6 @@ export type ResidenceSearchResult = Prisma.ResidenceGetPayload<{
   }
 }>
 
-export const getResidenceSizeById = async (residenceId: string) => {
-  try {
-    const result = await prisma.quantityValue
-      .findFirst({
-        where: {
-          quantityTypeId: 'BOA',
-          residence: {
-            id: residenceId,
-          },
-          quantityType: {
-            categoryLinks: {
-              some: { categoryId: 'balgh' },
-            },
-          },
-        },
-        include: {
-          quantityType: {
-            select: {
-              id: true,
-              name: true,
-              unitId: true,
-              categoryLinks: false,
-            },
-          },
-          residence: {
-            select: {
-              id: true,
-              name: true,
-            },
-          },
-        },
-      })
-      .then(trimStrings)
-
-    return result
-  } catch (err) {
-    logger.error({ err }, 'residence-adapter.getResidenceSizeById')
-    throw err
-  }
-}
-
 export const searchResidences = async (
   q: string
 ): Promise<Array<ResidenceSearchResult>> => {

--- a/packages/property-base/src/routes/residences-route.ts
+++ b/packages/property-base/src/routes/residences-route.ts
@@ -243,7 +243,7 @@ export const routes = (router: KoaRouter) => {
           : null
 
       // Get area size for the residence (yta)
-      const size = await getResidenceSizeByRentalId(rentalId)
+      const size = rentalId ? await getResidenceSizeByRentalId(rentalId) : null
 
       const mappedResidence = {
         id: residence.id,

--- a/packages/property-base/src/routes/residences-route.ts
+++ b/packages/property-base/src/routes/residences-route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 
 import {
   getResidenceById,
+  getResidenceSizeByRentalId,
   getResidencesByBuildingCode,
   getResidencesByBuildingCodeAndStaircaseCode,
   searchResidences,
@@ -241,6 +242,9 @@ export const routes = (router: KoaRouter) => {
           ? residence.propertyObject.propertyStructures[0].rentalId
           : null
 
+      // Get area size for the residence (yta)
+      const size = await getResidenceSizeByRentalId(rentalId)
+
       const mappedResidence = {
         id: residence.id,
         code: residence.code,
@@ -330,7 +334,7 @@ export const routes = (router: KoaRouter) => {
           name: residence.propertyObject.propertyStructures[0].buildingName,
         },
         malarEnergiFacilityId: residence.comments?.[0]?.text || null,
-        size: null, // Populate this with size from Andreas PR (YTA)
+        size: size?.value || null,
       } satisfies ResidenceDetails
 
       ctx.status = 200

--- a/packages/property-base/src/routes/residences-route.ts
+++ b/packages/property-base/src/routes/residences-route.ts
@@ -4,7 +4,6 @@ import { z } from 'zod'
 
 import {
   getResidenceById,
-  getResidenceSizeById,
   getResidencesByBuildingCode,
   getResidencesByBuildingCodeAndStaircaseCode,
   searchResidences,

--- a/packages/property-base/src/routes/residences-route.ts
+++ b/packages/property-base/src/routes/residences-route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 
 import {
   getResidenceById,
+  getResidenceSizeById,
   getResidencesByBuildingCode,
   getResidencesByBuildingCodeAndStaircaseCode,
   searchResidences,
@@ -234,8 +235,11 @@ export const routes = (router: KoaRouter) => {
         ctx.status = 404
         return
       }
-
       // TODO: find out why building is null in residence
+
+      // We need to get the size of the residence separately because of the way
+      // the database is structured. The size is stored in the cmval table
+      const residenceSizeResult = await getResidenceSizeById(id)
 
       const rentalId =
         residence.propertyObject?.propertyStructures?.length > 0
@@ -331,6 +335,7 @@ export const routes = (router: KoaRouter) => {
           name: residence.propertyObject.propertyStructures[0].buildingName,
         },
         malarEnergiFacilityId: residence.comments?.[0].text || null,
+        size: residenceSizeResult?.value || null,
       } satisfies ResidenceDetails
 
       ctx.status = 200

--- a/packages/property-base/src/routes/residences-route.ts
+++ b/packages/property-base/src/routes/residences-route.ts
@@ -237,10 +237,6 @@ export const routes = (router: KoaRouter) => {
       }
       // TODO: find out why building is null in residence
 
-      // We need to get the size of the residence separately because of the way
-      // the database is structured. The size is stored in the cmval table
-      const residenceSizeResult = await getResidenceSizeById(id)
-
       const rentalId =
         residence.propertyObject?.propertyStructures?.length > 0
           ? residence.propertyObject.propertyStructures[0].rentalId
@@ -335,7 +331,7 @@ export const routes = (router: KoaRouter) => {
           name: residence.propertyObject.propertyStructures[0].buildingName,
         },
         malarEnergiFacilityId: residence.comments?.[0]?.text || null,
-        size: residenceSizeResult?.value || null,
+        size: null, // Populate this with size from Andreas PR (YTA)
       } satisfies ResidenceDetails
 
       ctx.status = 200

--- a/packages/property-base/src/types/residence.ts
+++ b/packages/property-base/src/types/residence.ts
@@ -125,6 +125,7 @@ export const ResidenceDetailedSchema = z.object({
     code: z.string().nullable(),
   }),
   malarEnergiFacilityId: z.string().nullable(),
+  size: z.number().nullable(),
 })
 
 export type ExternalResidence = z.infer<typeof ResidenceSchema>

--- a/packages/property-tree/src/components/residence/ResidenceBasicInfo.tsx
+++ b/packages/property-tree/src/components/residence/ResidenceBasicInfo.tsx
@@ -67,8 +67,7 @@ export const ResidenceBasicInfo = ({ residence }: ResidenceBasicInfoProps) => {
             <div>
               <p className="text-sm text-muted-foreground">Yta</p>
               <p className="font-medium">
-                N/A
-                {/* {residence.size ? `${residence.size} m²` : '-'} */}
+                {residence.size ? `${residence.size} m²` : '-'}
               </p>
             </div>
             <div>

--- a/packages/property-tree/src/services/api/core/generated/api-types.ts
+++ b/packages/property-tree/src/services/api/core/generated/api-types.ts
@@ -2436,6 +2436,7 @@ export interface components {
         code: string | null;
       };
       malarEnergiFacilityId: string | null;
+      size: number | null;
     };
     Staircase: {
       id: string;

--- a/packages/property-tree/src/services/api/generated/api-types.ts
+++ b/packages/property-tree/src/services/api/generated/api-types.ts
@@ -637,6 +637,7 @@ export interface components {
         code: string | null;
       };
       malarEnergiFacilityId: string | null;
+      size: number | null;
     };
     ResidenceSearchResult: {
       id: string;


### PR DESCRIPTION
* Added new prisma models for the famous cmval table and it's relations required in order to fetch yta (BOA)
* Created prisma query in adapters to re-create a cmval table join used by @osirisguitar for fetching the value (had do modify it to get the residence size and not the whole building)
* Updated schemas
* Updated UI to include the value